### PR TITLE
Post anonymous check checked consistently for inline regular and adva…

### DIFF
--- a/local/lae/tests/behat/add_forum_anon.feature
+++ b/local/lae/tests/behat/add_forum_anon.feature
@@ -39,12 +39,11 @@ Feature: Add an anonymous forum
     And I log in as "student1"
     And I am on "Course 1" course homepage
     And I follow "Test forum name"
-    Then "input[name=anonymous]" "css_element" should not be visible
     And I follow "Add a new discussion topic"
-    Then "input[name=anonymous]" "css_element" should be visible
+    Then "input[name=anonymous]" "css_element" should not be visible
     And I set the field "subject" to "Post 1 subject"
     And I set the field "id_message" to "Body 1 content"
-    And the "input[name=anonymous]" "css_element" should be disabled
+    And the "input[id=id_anonymous]" "css_element" should be disabled
     And I press "Post to forum"
     Then I should see "Anonymous User"
     And I follow "Post 1 subject"

--- a/mod/forum/classes/post_form.php
+++ b/mod/forum/classes/post_form.php
@@ -124,6 +124,8 @@ class mod_forum_post_form extends moodleform {
             $mform->addElement('checkbox', 'anonymous', get_string('forum:anonymouspost', 'local_lae'));
         } else if ($forum->anonymous == FORUM_ANONYMOUS_ALWAYS && ($post->userid != $CFG->anonymous_userid) && empty($post->id)) {
             $mform->addElement('checkbox', 'anonymous', get_string('forum:anonymouspost', 'local_lae'), null, array('disabled' => 1));
+            $mform->setDefault('anonymous', true);
+            $mform->freeze('anonymous');
         }
 
         if (!$inpagereply) {

--- a/mod/forum/templates/inpage_reply.mustache
+++ b/mod/forum/templates/inpage_reply.mustache
@@ -63,7 +63,7 @@
                 <div class="form-check form-check-inline">
                     <input
                         {{#mustreplyanonymously}}
-                        disabled="disabled"
+                        disabled="disabled", checked="checked"
                         {{/mustreplyanonymously}}
                         type="checkbox" class="form-check-input" id="anonymous-reply-checkbox-{{uniqid}}" title="{{#str}} anonymousreply, forum {{/str}}" name="anonymousreply"/>
                     <label class="form-check-label" for="anonymous-reply-checkbox-{{uniqid}}">{{#str}} anonymousreply, forum {{/str}}</label>


### PR DESCRIPTION
Anonymous post - Newly added 'post anonymous' for inline is disabled but unchecked.
When the user chooses Post anonymously - Always. The newly added post anonymous option for inline is unchecked and disabled whereas for advanced post anonymous option is checked and disabled which is correct functionality. But the advance option is also not consistent when you are adding a new discussion topic. So we made the checkbox checked and disabled in all the places to keep it consistent as needed.


**Testing Instructions:**

TEST CASE 1: 

Go to any course and turn editing on from the top right corner.

Add a forum > Select the option ‘Yes, always’ for Anonymize posts? option.

Save display course

Now click on the forum you created. 

TEST CASE 1A:

Click on 'Create a new discussion forum

<img width="994" alt="Create a new discussion" src="https://user-images.githubusercontent.com/12834134/79498882-e5050480-7fde-11ea-8f16-64de98c788a8.png">

Notice that the checkbox for post anonymous option is checked and disabled.

TEST CASE 1B:

Click on the Advanced link on the right to Cancel button

<img width="988" alt="New discussion post - Advanced" src="https://user-images.githubusercontent.com/12834134/79498988-17166680-7fdf-11ea-8be5-aef50b078c2b.png">

Notice that the checkbox for post anonymous option is checked and disabled.

TEST CASE 1C:

Now click on the reply link to the newly created forum post.

<img width="1345" alt="inline reply" src="https://user-images.githubusercontent.com/12834134/79498303-ef72ce80-7fdd-11ea-925b-8390e9f5ca1e.png">

Notice that the checkbox for post anonymous option is checked and disabled. (This option is available next to cancel button.)

TEST CASE 1D:

Now click on the reply link to the newly created forum post.

Choose to click on the Advanced link on the right corner.

<img width="720" alt="inline reply with advanced" src="https://user-images.githubusercontent.com/12834134/79498976-0f56c200-7fdf-11ea-8bee-1a20e97ca5a5.png">


Notice that the checkbox for post anonymous option is checked and disabled. 

TEST CASE 2:

Go to any course and turn editing on from the top right corner.

Add a forum > Select the option ‘yes, let the user decide’ for post anonymous.

Save display course  (OR simply go to the above forum you created > Edit settings > Choose the drop-down option ‘yes, let the user decide’ > save)

Now click on the forum you created/edited.

TEST CASE 2A:

Click on 'Create a new discussion forum

Notice that the checkbox for post anonymous option is unchecked and editable.

TEST CASE 2B:

Click on the Advanced link on the right to Cancel button

Notice that the checkbox for post anonymous option is unchecked and editable. (This option is available next to cancel button.)

TEST CASE 2C:

Now click on the reply link to the newly created forum post.

Notice that the checkbox for post anonymous option is unchecked and editable. (This option is available next to cancel button.)

TEST CASE 2D:

Now click on the reply link to the newly created forum post.

Choose to click on the Advanced link on the right corner.

Notice that the checkbox for post anonymous option is unchecked and editable. 

TEST CASE 3:

Go to any course and turn editing on from the top right corner.

Add a forum > Select the option ‘no, never for post anonymous.

Save display course  (OR simply go to the above forum you created > Edit settings > Choose the drop-down option ‘no,never’ > save)

Now click on the forum you created/edited.

TEST CASE 3A:

Click on 'Create a new discussion forum

Notice that the checkbox for post anonymous doesn’t exist.

TEST CASE 3B:

Click on the Advanced link on the right to Cancel button

Notice that the checkbox for post anonymous doesn’t exist.

TEST CASE 3C:

Now click on the reply link to the newly created forum post.

Notice that the checkbox for post anonymous doesn’t exist.

TEST CASE 3D:

Now click on the reply link to the newly created forum post.

Choose to click on the Advanced link on the right corner.

Notice that the checkbox for post anonymous doesn’t exist. 